### PR TITLE
Add offline skill validation and legacy docs fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ wheels/
 .venv/
 venv/
 .doc/
+.codex/skills/

--- a/README.md
+++ b/README.md
@@ -54,12 +54,15 @@ The tool generates a skill directory in `.claude/skills/<skill_name>/` containin
 ```
 <skill_name>/
 ├── SKILL.md           # Entry point with usage instructions
-├── docs/              # Markdown documentation files
+├── references/        # Markdown documentation files (preferred)
 └── scripts/
     └── search_docs.py # Search tool for documentation
 ```
 
 Additionally, a `<skill_name>.skill` file (ZIP archive) is created in the current directory.
+
+Legacy note: older skills may use `docs/` instead of `references/`. The search tool and validator
+now support both, preferring `references/` when present.
 
 ### Search Tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,6 @@ site2skill = ["templates/*"]
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "skills-ref; python_version >= '3.11'",
 ]
 # No special uv settings needed yet

--- a/site2skill/generate_skill_structure.py
+++ b/site2skill/generate_skill_structure.py
@@ -17,17 +17,17 @@ logger = logging.getLogger(__name__)
 
 def generate_skill_structure(skill_name: str, source_dir: Optional[str], output_base: str = ".claude/skills") -> None:
     """
-    Generate the Skill structure following SKILL.md + docs/ pattern.
+    Generate the Skill structure following SKILL.md + references/ pattern.
     Structure:
       <skill-name>/
         SKILL.md         # Entry point, usage instructions
-        docs/            # Documentation files (preserves directory structure)
+        references/      # Documentation files (preserves directory structure)
         scripts/         # (Optional) Executable code
     """
     skill_dir = os.path.join(output_base, skill_name)
 
     # Define subdirectories
-    docs_dir = os.path.join(skill_dir, "docs")
+    references_dir = os.path.join(skill_dir, "references")
     scripts_dir = os.path.join(skill_dir, "scripts")
 
     # Create directories
@@ -36,7 +36,7 @@ def generate_skill_structure(skill_name: str, source_dir: Optional[str], output_
     else:
         os.makedirs(skill_dir)
 
-    os.makedirs(docs_dir, exist_ok=True)
+    os.makedirs(references_dir, exist_ok=True)
     os.makedirs(scripts_dir, exist_ok=True)
 
     # Create SKILL.md
@@ -54,7 +54,8 @@ This skill provides access to {skill_name.upper()} documentation.
 
 ## Documentation
 
-All documentation files are in the `docs/` directory as Markdown files.
+All documentation files are in the `references/` directory as Markdown files.
+For legacy skills, documentation may live in `docs/`.
 
 ## Search Tool
 
@@ -68,7 +69,7 @@ Options:
 
 ## Usage
 
-1. Search or read files in `docs/` for relevant information
+1. Search or read files in `references/` for relevant information (fallback to `docs/` for legacy)
 2. Each file has frontmatter with `source_url` and `fetched_at`
 3. Always cite the source URL in responses
 4. Note the fetch date - documentation may have changed
@@ -115,13 +116,13 @@ Options:
                     
                     # Preserve directory structure relative to source_dir
                     rel_path = os.path.relpath(src_path, source_dir)
-                    dst_path = os.path.join(docs_dir, rel_path)
+                    dst_path = os.path.join(references_dir, rel_path)
 
-                    # Security check: Ensure dst_path is strictly within docs_dir
+                    # Security check: Ensure dst_path is strictly within references_dir
                     abs_dst_path = os.path.abspath(dst_path)
-                    abs_docs_dir = os.path.abspath(docs_dir)
+                    abs_references_dir = os.path.abspath(references_dir)
 
-                    if os.path.commonpath([abs_dst_path, abs_docs_dir]) != abs_docs_dir:
+                    if os.path.commonpath([abs_dst_path, abs_references_dir]) != abs_references_dir:
                         logger.warning(f"Skipping potential path traversal file: {file}")
                         continue
                     
@@ -133,7 +134,7 @@ Options:
                     shutil.copy2(src_path, dst_path)
                     file_count += 1
 
-        logger.info(f"Copied {file_count} files to docs/")
+        logger.info(f"Copied {file_count} files to references/")
     else:
         logger.warning(f"Source directory {source_dir} not found or empty.")
 

--- a/site2skill/templates/scripts_README.md
+++ b/site2skill/templates/scripts_README.md
@@ -4,7 +4,7 @@ This directory contains helper tools for working with this skill.
 
 ## search_docs.py
 
-Full-text search across all documentation files.
+Full-text search across all documentation files (prefers references/, falls back to docs/).
 
 **Usage:**
 ```bash

--- a/site2skill/templates/search_docs.py
+++ b/site2skill/templates/search_docs.py
@@ -2,7 +2,7 @@
 """
 search_docs.py - Full-text search tool for Claude Code Skills
 
-This script searches through the Markdown documentation files in the data/ directory.
+This script searches through the Markdown documentation files in the references/ directory.
 It provides context-aware results, extracting relevant snippets around matched terms.
 """
 
@@ -126,16 +126,21 @@ def search_docs(skill_dir: Path, query: str, max_results: int = 10) -> List[Dict
     Returns:
         List of result dictionaries
     """
+    references_dir = skill_dir / "references"
     docs_dir = skill_dir / "docs"
-    if not docs_dir.exists():
-        print(f"Error: {docs_dir} not found.")
+    if references_dir.exists():
+        content_dir = references_dir
+    elif docs_dir.exists():
+        content_dir = docs_dir
+    else:
+        print(f"Error: {references_dir} (or {docs_dir}) not found.")
         return []
 
     keywords = query.lower().split()
     results = []
 
-    # Walk through all markdown files in docs/
-    for file_path in docs_dir.glob("**/*.md"):
+    # Walk through all markdown files in references/ (fallback to docs/)
+    for file_path in content_dir.glob("**/*.md"):
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
                 content = f.read()

--- a/site2skill/utils.py
+++ b/site2skill/utils.py
@@ -20,10 +20,10 @@ def sanitize_path(path: str) -> str:
         after sanitization, returns "file.md" as a safe default.
         
     Examples:
-        >>> sanitize_path("docs.example.com/api/index.md")
-        'docs.example.com/api/index.md'
-        >>> sanitize_path("docs@example.com/api#v1/index.md")
-        'docs_example.com/api_v1/index.md'
+        >>> sanitize_path("references.example.com/api/index.md")
+        'references.example.com/api/index.md'
+        >>> sanitize_path("references@example.com/api#v1/index.md")
+        'references_example.com/api_v1/index.md'
         >>> sanitize_path("")
         'file.md'
     """
@@ -51,18 +51,18 @@ def html_to_md_path(html_path: str) -> str:
     Convert an HTML file path to a corresponding markdown file path.
     
     Args:
-        html_path: Path to HTML file (e.g., "docs/page.html")
+        html_path: Path to HTML file (e.g., "references/page.html")
         
     Returns:
-        Path to markdown file (e.g., "docs/page.md")
+        Path to markdown file (e.g., "references/page.md")
         
     Examples:
-        >>> html_to_md_path("docs/index.html")
-        'docs/index.md'
+        >>> html_to_md_path("references/index.html")
+        'references/index.md'
         >>> html_to_md_path("page.html")
         'page.md'
-        >>> html_to_md_path("docs/page")
-        'docs/page.md'
+        >>> html_to_md_path("references/page")
+        'references/page.md'
     """
     if html_path.endswith('.html'):
         return html_path[:-5] + '.md'

--- a/site2skill/validate_skill.py
+++ b/site2skill/validate_skill.py
@@ -10,20 +10,30 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
+def _get_docs_dir(skill_dir: str) -> str | None:
+    references_dir = os.path.join(skill_dir, "references")
+    if os.path.isdir(references_dir):
+        return references_dir
+    docs_dir = os.path.join(skill_dir, "docs")
+    if os.path.isdir(docs_dir):
+        return docs_dir
+    return None
+
+
 def check_skill_size(skill_dir: str) -> None:
     """
-    Checks the total size of the skill directory (specifically docs/).
+    Checks the total size of the skill directory (references/ preferred, fallback to docs/).
     Warns if it exceeds 8MB.
     Lists top 10 largest files.
     """
-    docs_dir = os.path.join(skill_dir, "docs")
-    if not os.path.exists(docs_dir):
+    content_dir = _get_docs_dir(skill_dir)
+    if not content_dir:
         return
 
     total_size = 0
     file_sizes: List[Tuple[int, str]] = []
 
-    for root, _, files in os.walk(docs_dir):
+    for root, _, files in os.walk(content_dir):
         for f in files:
             fp = os.path.join(root, f)
             try:
@@ -56,7 +66,7 @@ def check_skill_size(skill_dir: str) -> None:
 def validate_skill(skill_dir: str) -> bool:
     """
     Validates a skill directory structure and metadata.
-    Checks for SKILL.md + docs/ structure.
+    Checks for SKILL.md + references/ structure (fallback to docs/).
     """
     logger.info(f"Validating skill in: {skill_dir}")
 
@@ -95,22 +105,30 @@ def validate_skill(skill_dir: str) -> bool:
         except Exception as e:
             warnings.append(f"Could not validate SKILL.md: {e}")
 
-    # 3. Check docs/ directory
+    # 3. Check references/ directory (fallback to docs/)
+    references_dir = os.path.join(skill_dir, "references")
     docs_dir = os.path.join(skill_dir, "docs")
-    if not os.path.isdir(docs_dir):
-        errors.append("docs/ directory not found.")
+    if os.path.isdir(references_dir):
+        logger.info("Found references/")
+        content_dir = references_dir
+    elif os.path.isdir(docs_dir):
+        warnings.append("references/ not found, using legacy docs/ directory")
+        logger.info("Found docs/ (legacy)")
+        content_dir = docs_dir
     else:
-        logger.info("Found docs/")
+        errors.append("references/ directory not found (and no legacy docs/).")
+        content_dir = None
 
+    if content_dir:
         # Count markdown files
         md_files = []
-        for root, _, files in os.walk(docs_dir):
+        for root, _, files in os.walk(content_dir):
             for file in files:
                 if file.endswith('.md'):
                     md_files.append(os.path.join(root, file))
 
         if len(md_files) == 0:
-            warnings.append("docs/ directory is empty (no .md files)")
+            warnings.append(f"{os.path.basename(content_dir)}/ directory is empty (no .md files)")
         else:
             logger.info(f"  {len(md_files)} markdown files")
 

--- a/test_agentskills_integration.py
+++ b/test_agentskills_integration.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from site2skill.generate_skill_structure import generate_skill_structure
+
+
+def test_agentskills_validate_generated_skill():
+    pytest.importorskip("skills_ref")
+
+    fixture_dir = os.path.join(
+        os.path.dirname(__file__),
+        "tests",
+        "fixtures",
+        "site2skill",
+        "markdown",
+    )
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        output_base = os.path.join(temp_dir, "skills")
+        generate_skill_structure("example-skill", fixture_dir, output_base)
+        skill_dir = os.path.join(output_base, "example-skill")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "skills_ref.cli", "validate", skill_dir],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+    finally:
+        shutil.rmtree(temp_dir)

--- a/test_integration.py
+++ b/test_integration.py
@@ -115,7 +115,7 @@ def run_conversion_pipeline(crawl_dir, temp_base):
 
 def verify_results(skill_dir):
     """Verify the final skill structure."""
-    docs_dir = os.path.join(skill_dir, "docs")
+    references_dir = os.path.join(skill_dir, "references")
     
     # Expected files based on our test structure
     expected_files = [
@@ -135,7 +135,7 @@ def verify_results(skill_dir):
     
     print("\n=== Verifying Final Skill Structure ===")
     for expected in expected_files:
-        expected_path = os.path.join(docs_dir, expected)
+        expected_path = os.path.join(references_dir, expected)
         if os.path.exists(expected_path):
             # Verify content
             with open(expected_path, 'r') as f:
@@ -150,10 +150,10 @@ def verify_results(skill_dir):
             all_passed = False
     
     # Count index.md files
-    all_files = glob.glob(os.path.join(docs_dir, "**/*.md"), recursive=True)
+    all_files = glob.glob(os.path.join(references_dir, "**/*.md"), recursive=True)
     index_files = [f for f in all_files if f.endswith("index.md")]
     
-    print(f"\nTotal files in docs/: {len(all_files)}")
+    print(f"\nTotal files in references/: {len(all_files)}")
     print(f"Index.md files: {len(index_files)}")
     
     # We should have 6 different index.md files
@@ -213,4 +213,3 @@ def test_integration_pipeline():
 
 if __name__ == "__main__":
     test_integration_pipeline()
-

--- a/test_site2skill.py
+++ b/test_site2skill.py
@@ -10,8 +10,8 @@ class TestSite2Skill(unittest.TestCase):
     def test_sanitize_path(self):
         """Test the sanitize_path utility function."""
         # Standard cases
-        self.assertEqual(sanitize_path("docs.example.com/api/index.md"), 'docs.example.com/api/index.md')
-        self.assertEqual(sanitize_path("docs@example.com/api#v1/index.md"), 'docs_example.com/api_v1/index.md')
+        self.assertEqual(sanitize_path("references.example.com/api/index.md"), 'references.example.com/api/index.md')
+        self.assertEqual(sanitize_path("references@example.com/api#v1/index.md"), 'references_example.com/api_v1/index.md')
         
         # Edge cases
         self.assertEqual(sanitize_path(""), 'file.md')
@@ -45,10 +45,10 @@ class TestSite2Skill(unittest.TestCase):
             skill_dir = os.path.join(self.output_base, skill_name)
             self.assertTrue(os.path.exists(os.path.join(skill_dir, "SKILL.md")), "SKILL.md should be created")
             
-            # Verify docs content
-            docs_dir = os.path.join(skill_dir, "docs")
-            self.assertTrue(os.path.exists(os.path.join(docs_dir, "root.md")), "root.md should be copied")
-            self.assertTrue(os.path.exists(os.path.join(docs_dir, "sub", "nested.md")), "nested.md should be copied in subdir")
+            # Verify references content
+            references_dir = os.path.join(skill_dir, "references")
+            self.assertTrue(os.path.exists(os.path.join(references_dir, "root.md")), "root.md should be copied")
+            self.assertTrue(os.path.exists(os.path.join(references_dir, "sub", "nested.md")), "nested.md should be copied in subdir")
             
             # Verify scripts
             scripts_dir = os.path.join(skill_dir, "scripts")

--- a/tests/fixtures/site2skill/markdown/example.com/index.md
+++ b/tests/fixtures/site2skill/markdown/example.com/index.md
@@ -1,0 +1,10 @@
+---
+title: "Example Home"
+source_url: "https://example.com/"
+fetched_at: "2026-01-30T00:00:00+00:00"
+---
+
+# Example Docs
+
+This is a fixture page for site2skill integration tests.
+

--- a/tests/fixtures/site2skill/markdown/example.com/specification.md
+++ b/tests/fixtures/site2skill/markdown/example.com/specification.md
@@ -1,0 +1,10 @@
+---
+title: "Example Specification"
+source_url: "https://example.com/specification"
+fetched_at: "2026-01-30T00:00:00+00:00"
+---
+
+# Specification
+
+This is a fixture specification page for site2skill integration tests.
+

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version < '3.11'",
+]
 
 [[package]]
 name = "beautifulsoup4"
@@ -28,6 +32,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -41,7 +57,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -113,6 +129,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -193,6 +221,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "skills-ref", marker = "python_full_version >= '3.11'" },
 ]
 
 [package.metadata]
@@ -204,7 +233,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "skills-ref", marker = "python_full_version >= '3.11'" },
+]
 
 [[package]]
 name = "six"
@@ -216,12 +248,37 @@ wheels = [
 ]
 
 [[package]]
+name = "skills-ref"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "python_full_version >= '3.11'" },
+    { name = "strictyaml", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/42/943d3ba8b097af7068b7178563a5062ad8a977982f4a7b4f67facfc575e9/skills_ref-0.1.1.tar.gz", hash = "sha256:6b400ca6e0049be62dca0167ff943ba2745fd67efb37fbba4d0ee341fccd2695", size = 93519, upload-time = "2026-01-10T13:23:41.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/25/36a43c3a61fb6cc3984e6ad5e556929b8ae71c95eba615dae4cf2f427964/skills_ref-0.1.1-py3-none-any.whl", hash = "sha256:d35db5bb8de71ae301daf5ca9cb71f8a555e8c6f83a6d40e46a5bc09f8f461b5", size = 12918, upload-time = "2026-01-10T13:23:40.106Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

We want CI validation of generated skills without network dependency, and avoid breaking existing users who still have docs/ instead of references/.

## What changed

- Added an offline integration test that generates a skill from recorded markdown fixtures and validates it with skills-ref.
- Added a minimal markdown fixture under tests/fixtures for deterministic generation.
- Added backwards compatibility so validation and search prefer references/ but fall back to legacy docs/.
- Updated SKILL.md template/docs to mention the legacy path and updated README/script docs accordingly.
- Added skills-ref as a dev dependency (Python 3.11+ marker).
- Ignored .codex/skills in .gitignore.

## How to test

uv sync --dev
uv run pytest