### PR TITLE
Enhance skill generation with target agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ uvx --from git+https://github.com/laiso/site2skill site2skill https://docs.pay.j
 site2skill <URL> <SKILL_NAME> [options]
 
 Options:
-  --output, -o       Base output directory for skill structure (default: .claude/skills)
+  --target           Target agent (claude|claude-desktop|cursor|gemini|codex). Sets default output directory
+  --output, -o       Base output directory for skill structure (overrides target default)
   --skill-output     Output directory for .skill file (default: .)
   --temp-dir         Temporary directory for processing (default: build)
   --skip-fetch       Skip the download step (use existing files in temp dir)

--- a/site2skill/generate_skill_structure.py
+++ b/site2skill/generate_skill_structure.py
@@ -15,7 +15,12 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
-def generate_skill_structure(skill_name: str, source_dir: Optional[str], output_base: str = ".claude/skills") -> None:
+def generate_skill_structure(
+    skill_name: str,
+    source_dir: Optional[str],
+    output_base: str = ".claude/skills",
+    target_agent: Optional[str] = None,
+) -> None:
     """
     Generate the Skill structure following SKILL.md + references/ pattern.
     Structure:
@@ -42,11 +47,18 @@ def generate_skill_structure(skill_name: str, source_dir: Optional[str], output_
     # Create SKILL.md
     skill_md_path = os.path.join(skill_dir, "SKILL.md")
     if not os.path.exists(skill_md_path):
+        frontmatter_lines = [
+            "---",
+            f"name: {skill_name}",
+            f"description: {skill_name.upper()} documentation assistant",
+        ]
+        if target_agent:
+            frontmatter_lines.append("metadata:")
+            frontmatter_lines.append(f"  target_agent: {target_agent}")
+        frontmatter_lines.append("---")
+        frontmatter = "\n".join(frontmatter_lines)
         with open(skill_md_path, "w", encoding="utf-8") as f:
-            f.write(f"""---
-name: {skill_name}
-description: {skill_name.upper()} documentation assistant
----
+            f.write(f"""{frontmatter}
 
 # {skill_name.upper()} Skill
 

--- a/site2skill/main.py
+++ b/site2skill/main.py
@@ -29,7 +29,18 @@ def main():
     parser = argparse.ArgumentParser(description="Web Docs to Claude Code Skill Pipeline")
     parser.add_argument("url", help="URL of the documentation site")
     parser.add_argument("skill_name", help="Name of the skill (e.g., payjp)")
-    parser.add_argument("--output", "-o", default=".claude/skills", help="Base output directory for skill structure")
+    parser.add_argument(
+        "--target",
+        choices=["claude", "claude-desktop", "cursor", "gemini", "codex"],
+        default="claude",
+        help="Target agent (sets default output directory)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Base output directory for skill structure (overrides target default)",
+    )
     parser.add_argument("--skill-output", default=".", help="Output directory for .skill file")
     parser.add_argument("--temp-dir", default="build", help="Temporary directory for processing")
     
@@ -40,6 +51,17 @@ def main():
     
     try:
         # 1. Setup Directories
+        output_base = args.output
+        if output_base is None:
+            target_output_map = {
+                "claude": ".claude/skills",
+                "claude-desktop": ".claude/skills",
+                "cursor": ".cursor/skills",
+                "gemini": ".gemini/skills",
+                "codex": ".codex/skills",
+            }
+            output_base = target_output_map[args.target]
+
         temp_download_dir = os.path.join(args.temp_dir, "download")
         temp_md_dir = os.path.join(args.temp_dir, "markdown")
         
@@ -116,9 +138,14 @@ def main():
             normalize_markdown(md_file, md_file)
             
         logger.info(f"=== Step 4: Generating Skill Structure ===")
-        generate_skill_structure(args.skill_name, temp_md_dir, args.output)
+        generate_skill_structure(
+            args.skill_name,
+            temp_md_dir,
+            output_base,
+            target_agent=args.target,
+        )
         
-        skill_dir = os.path.join(args.output, args.skill_name)
+        skill_dir = os.path.join(output_base, args.skill_name)
         
         logger.info(f"=== Step 5: Validating Skill ===")
         if not validate_skill(skill_dir):
@@ -127,12 +154,17 @@ def main():
         
         # Note: check_skill_size is now called inside validate_skill
         
-        logger.info(f"=== Step 6: Packaging Skill ===")
-        skill_file = package_skill(skill_dir, args.skill_output)
+        skill_file = None
+        if args.target == "claude-desktop":
+            logger.info(f"=== Step 6: Packaging Skill ===")
+            skill_file = package_skill(skill_dir, args.skill_output)
+        else:
+            logger.info("=== Step 6: Packaging Skill (skipped for non-claude-desktop targets) ===")
 
         logger.info(f"=== Done! ===")
         logger.info(f"Skill directory: {skill_dir}")
-        logger.info(f"Skill package: {skill_file}")
+        if skill_file:
+            logger.info(f"Skill package: {skill_file}")
         
         # Cleanup
         if args.clean:

--- a/test_site2skill.py
+++ b/test_site2skill.py
@@ -39,11 +39,19 @@ class TestSite2Skill(unittest.TestCase):
                 
             # Run generator
             skill_name = "test_skill"
-            generate_skill_structure(skill_name, self.source_dir, self.output_base)
+            generate_skill_structure(
+                skill_name,
+                self.source_dir,
+                self.output_base,
+                target_agent="cursor",
+            )
             
             # Verify structure
             skill_dir = os.path.join(self.output_base, skill_name)
             self.assertTrue(os.path.exists(os.path.join(skill_dir, "SKILL.md")), "SKILL.md should be created")
+            with open(os.path.join(skill_dir, "SKILL.md"), "r", encoding="utf-8") as f:
+                skill_md = f.read()
+            self.assertIn("target_agent: cursor", skill_md, "SKILL.md should include target_agent metadata")
             
             # Verify references content
             references_dir = os.path.join(skill_dir, "references")


### PR DESCRIPTION
site2skill now supports target-specific output paths. The output directory is automatically selected based on the target.

## What’s new

- --target switches the default output location (claude / claude-desktop / cursor / gemini / codex)
- --output overrides the target-based default
- .skill (ZIP) packaging runs only for claude-desktop; other targets output directories only

## Examples

### Generate a skill for Cursor
site2skill <URL> <SKILL_NAME> --target cursor

### Generate a skill for Codex
site2skill <URL> <SKILL_NAME> --target codex

###  Claude Desktop (with ZIP packaging)
site2skill <URL> <SKILL_NAME> --target claude-desktop