### PR TITLE
Fix security and correctness issues from Codex subagent review

### DIFF
--- a/src/fetch/robots.rs
+++ b/src/fetch/robots.rs
@@ -24,9 +24,7 @@ impl RobotsTxtCache {
 
     /// Check if a URL is allowed by robots.txt
     pub async fn is_allowed(&self, url: &Url) -> Result<bool, CrawlerError> {
-        let scheme = url.scheme();
-        let host = url.host_str().unwrap_or("");
-        let robots_url = format!("{}://{}/robots.txt", scheme, host);
+        let robots_url = robots_txt_url(url);
 
         // Check cache first
         {
@@ -49,13 +47,13 @@ impl RobotsTxtCache {
         // Cache the result
         {
             let mut cache_guard = self.cache.write().await;
-            cache_guard.insert(robots_url, robots);
+            cache_guard.insert(robots_url.clone(), robots);
         }
 
         // Check if allowed
         {
             let cache_guard = self.cache.read().await;
-            if let Some(robots) = cache_guard.get(&format!("{}://{}/robots.txt", scheme, host)) {
+            if let Some(robots) = cache_guard.get(&robots_url) {
                 return Ok(robots.is_allowed(url.path(), "site2skill"));
             }
         }
@@ -74,6 +72,16 @@ impl RobotsTxtCache {
                 Ok(None)
             }
         }
+    }
+}
+
+fn robots_txt_url(url: &Url) -> String {
+    let scheme = url.scheme();
+    let host = url.host_str().unwrap_or("");
+
+    match url.port_or_known_default() {
+        Some(port) => format!("{}://{}:{}/robots.txt", scheme, host, port),
+        None => format!("{}://{}/robots.txt", scheme, host),
     }
 }
 
@@ -130,30 +138,47 @@ impl RobotsTxt {
         }
     }
 
-    /// Check if a path is allowed
+    /// Check if a path is allowed using longest-match semantics
     pub fn is_allowed(&self, path: &str, _user_agent: &str) -> bool {
-        // Check allow rules first (more specific)
+        let mut longest_match_len: usize = 0;
+        let mut longest_match_is_allow = true; // default: allowed
+
         for rule in &self.allow_rules {
-            if path.starts_with(rule) {
-                return true;
+            if path.starts_with(rule) && rule.len() > longest_match_len {
+                longest_match_len = rule.len();
+                longest_match_is_allow = true;
             }
         }
 
-        // Check disallow rules
         for rule in &self.disallow_rules {
-            if path.starts_with(rule) {
-                return false;
+            if path.starts_with(rule) && rule.len() > longest_match_len {
+                longest_match_len = rule.len();
+                longest_match_is_allow = false;
             }
         }
 
-        // Default: allowed
-        true
+        longest_match_is_allow
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_robots_url_keeps_non_default_port() {
+        let url = Url::parse("http://localhost:3000/docs").unwrap();
+        assert_eq!(robots_txt_url(&url), "http://localhost:3000/robots.txt");
+    }
+
+    #[test]
+    fn test_robots_url_normalizes_default_https_port() {
+        let implicit = Url::parse("https://example.com/docs").unwrap();
+        let explicit = Url::parse("https://example.com:443/docs").unwrap();
+
+        assert_eq!(robots_txt_url(&implicit), "https://example.com:443/robots.txt");
+        assert_eq!(robots_txt_url(&explicit), "https://example.com:443/robots.txt");
+    }
 
     #[test]
     fn test_robots_parse() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
 
+    // Validate skill_name to prevent path traversal
+    if args.skill_name.contains("..") || args.skill_name.contains('/') || args.skill_name.contains('\\') || args.skill_name.starts_with('-') {
+        error!("Invalid skill name: {:?}. Must not contain path separators or '..'", args.skill_name);
+        std::process::exit(1);
+    }
+
     // Determine output base directory
     let output_base = args.output.unwrap_or_else(|| {
         PathBuf::from(args.target.default_output_dir())
@@ -196,12 +202,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let validation_result = validate_skill(&skill_dir)?;
     if !validation_result.is_valid {
         error!("Validation failed. Please check errors.");
-        for err in validation_result.errors {
+        for err in &validation_result.errors {
             error!("  - {}", err);
         }
     }
-    for warning in validation_result.warnings {
+    for warning in &validation_result.warnings {
         warn!("  - {}", warning);
+    }
+    if !validation_result.is_valid {
+        std::process::exit(1);
     }
 
     // Step 6: Package Skill

--- a/src/skill/package.rs
+++ b/src/skill/package.rs
@@ -55,12 +55,26 @@ pub fn package_skill(skill_dir: &Path, output_dir: &Path) -> Result<PathBuf, Pac
             continue;
         }
 
+        // Skip symlinks to prevent zip-slip via symlink traversal
+        if entry.path_is_symlink() {
+            tracing::warn!("Skipping symlink in ZIP: {:?}", path);
+            continue;
+        }
+
         // Convert to Unix-style path for ZIP
         let zip_path = rel_path
             .components()
             .map(|c| c.as_os_str().to_string_lossy())
             .collect::<Vec<_>>()
             .join("/");
+
+        // Reject paths with traversal components or absolute paths
+        if zip_path.contains("..") || zip_path.starts_with('/') {
+            return Err(PackageError::IoError(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Invalid path in archive: {}", zip_path),
+            )));
+        }
 
         // Add file to ZIP
         zip.start_file(&zip_path, options)?;

--- a/src/skill/structure.rs
+++ b/src/skill/structure.rs
@@ -118,6 +118,12 @@ Options:
             .filter_map(|e| e.ok())
         {
             let path = entry.path();
+            // Skip symlinks to prevent reading files outside source_dir
+            if entry.path_is_symlink() {
+                warn!("Skipping symlink: {:?}", path);
+                continue;
+            }
+
             if path.is_file() && path.extension().map_or(false, |ext| ext == "md") {
                 let rel_path = path.strip_prefix(source_dir).unwrap_or(path);
 

--- a/src/url_filter.rs
+++ b/src/url_filter.rs
@@ -50,11 +50,14 @@ pub fn is_url_allowed(
         Err(_) => return false,
     };
 
-    // Scheme & host must match
+    // Scheme, host, and effective port must match.
     if start.scheme() != candidate.scheme() {
         return false;
     }
     if start.host_str() != candidate.host_str() {
+        return false;
+    }
+    if start.port_or_known_default() != candidate.port_or_known_default() {
         return false;
     }
 
@@ -151,6 +154,24 @@ mod tests {
         assert!(is_url_allowed(
             "https://example.com/docs",
             "https://example.com/docs/api/v1",
+            None
+        ));
+    }
+
+    #[test]
+    fn test_explicit_default_port_is_same_origin() {
+        assert!(is_url_allowed(
+            "https://example.com/docs",
+            "https://example.com:443/docs/page",
+            None
+        ));
+    }
+
+    #[test]
+    fn test_non_default_port_is_different_origin() {
+        assert!(!is_url_allowed(
+            "https://example.com/docs",
+            "https://example.com:8443/docs/page",
             None
         ));
     }


### PR DESCRIPTION
## Summary

- Fix zip-slip vulnerability in ZIP packaging: reject symlinks and validate entry paths
- Prevent path traversal via `skill_name` CLI argument
- Skip symlinks when copying source files to `references/`
- Fix robots.txt URL generation and crawl boundary to use `port_or_known_default()`, so non-default ports are preserved while explicit default ports (e.g. `:443`) are normalized
- Fix robots.txt matching to use longest-match semantics (RFC-compliant)
- Exit with non-zero status when skill validation fails

## Test plan

- [x] `cargo test` — 56 tests + 2 doc tests pass
- [x] New regression tests for port handling (`test_explicit_default_port_is_same_origin`, `test_non_default_port_is_different_origin`)
- [x] New regression tests for robots.txt URL generation (`test_robots_url_keeps_non_default_port`, `test_robots_url_normalizes_default_https_port`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)