### PR TITLE
Fix Windows wheel packaging for Rust beta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             platform_tag: macosx_10_9_x86_64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform_tag: win_amd64
 
     runs-on: ${{ matrix.os }}
 
@@ -53,10 +56,15 @@ jobs:
         run: pip install build
 
       - name: Build wheel
+        shell: bash
         run: |
           mkdir -p python/site2skill/bin
-          cp target/${{ matrix.target }}/release/site2skill python/site2skill/bin/
-          chmod +x python/site2skill/bin/site2skill
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp target/${{ matrix.target }}/release/site2skill.exe python/site2skill/bin/
+          else
+            cp target/${{ matrix.target }}/release/site2skill python/site2skill/bin/
+            chmod +x python/site2skill/bin/site2skill
+          fi
           cd python
           python -m build --wheel
           cd dist

--- a/python/site2skill/__init__.py
+++ b/python/site2skill/__init__.py
@@ -10,16 +10,14 @@ from pathlib import Path
 def get_binary_path() -> Path:
     """Return the path to the bundled binary."""
     package_dir = Path(__file__).parent
-    binary = package_dir / "bin" / "site2skill"
+    binary_name = "site2skill.exe" if sys.platform == "win32" else "site2skill"
+    binary = package_dir / "bin" / binary_name
 
     # Ensure binary is executable on Unix
-    if sys.platform != "win32":
-        if binary.exists():
-            current_mode = os.stat(binary).st_mode
-            if not (current_mode & stat.S_IXUSR):
-                os.chmod(
-                    binary, current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-                )
+    if sys.platform != "win32" and binary.exists():
+        current_mode = os.stat(binary).st_mode
+        if not (current_mode & stat.S_IXUSR):
+            os.chmod(binary, current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     return binary
 

--- a/scripts/build_wheels.py
+++ b/scripts/build_wheels.py
@@ -107,7 +107,7 @@ def build_rust_binary(target_dir: Path):
 def main():
     """Main build function."""
     # Get the python package directory
-    package_dir = Path(__file__).parent / "python" / "site2skill"
+    package_dir = Path(__file__).parent.parent / "python" / "site2skill"
 
     # Build Rust binary
     build_rust_binary(package_dir)


### PR DESCRIPTION
## Summary
- add a Windows `win_amd64` wheel build to the release workflow
- package `site2skill.exe` on Windows while keeping Unix executable handling unchanged
- make the Python shim resolve `site2skill.exe` on Windows
- fix the local wheel build helper path to point at `python/site2skill`

## Notes
This should allow `uvx --pre site2skill ...` to install the Rust beta on Windows without falling back to the legacy Python/wget version.

## Testing
- Built a wheel locally with a dummy `site2skill.exe`
- Verified `site2skill/bin/site2skill.exe` is included in the wheel
